### PR TITLE
fix: update http code of response from default code to cusstom code

### DIFF
--- a/backend/src/modules/auth/auth.controller.ts
+++ b/backend/src/modules/auth/auth.controller.ts
@@ -9,6 +9,8 @@ import {
   Headers,
   Req,
   Res,
+  HttpCode,
+  HttpStatus,
 } from '@nestjs/common';
 import { Public } from 'src/common/decorators/public.decorator';
 import { Request, Response } from 'express';
@@ -51,7 +53,7 @@ export class AuthController {
 
   @Public()
   @Post('login')
-  @ApiLoginDoc()
+  @HttpCode(HttpStatus.OK)
   @ApiLoginDoc()
   async login(
     @Body() loginDto: LoginDto,
@@ -67,7 +69,7 @@ export class AuthController {
 
   @Public()
   @Post('refresh')
-  @ApiRefreshTokensDoc()
+  @HttpCode(HttpStatus.OK)
   @ApiRefreshTokensDoc()
   async refresh(@Req() req: Request) {
     const refreshToken = req.cookies['refresh_token'];
@@ -76,6 +78,7 @@ export class AuthController {
   }
 
   @Post('logout')
+  @HttpCode(HttpStatus.OK)
   @ApiLogoutDoc()
   async logout(@Req() req: Request, @Res({ passthrough: true }) res: Response) {
     const accessToken = req.cookies['access_token'];
@@ -121,7 +124,7 @@ export class AuthController {
 
   @Public()
   @Post('google/token')
-  @ApiGoogleTokenLoginDoc()
+  @HttpCode(HttpStatus.OK)
   @ApiGoogleTokenLoginDoc()
   async googleTokenLogin(
     @Body() googleTokenDto: GoogleTokenDto,

--- a/backend/src/modules/auth/swagger/auth.swagger.ts
+++ b/backend/src/modules/auth/swagger/auth.swagger.ts
@@ -51,7 +51,7 @@ export const ApiLoginDoc = () => {
     }),
     ApiBody({ type: LoginDto }),
     ApiResponse({
-      status: 201,
+      status: 200,
       description:
         'Đăng nhập thành công. Tokens được trả về và lưu trong Cookie.',
       schema: {
@@ -91,7 +91,7 @@ export const ApiRefreshTokensDoc = () => {
       required: false,
     }),
     ApiResponse({
-      status: 201,
+      status: 200,
       description: 'Refresh thành công. Tokens mới được lưu vào Cookie.',
       schema: {
         type: 'object',
@@ -130,7 +130,7 @@ export const ApiLogoutDoc = () => {
       required: false,
     }),
     ApiResponse({
-      status: 201,
+      status: 200,
       description: 'Đăng xuất thành công. Cookies sẽ bị xóa.',
       schema: {
         type: 'object',
@@ -202,7 +202,7 @@ export const ApiGoogleTokenLoginDoc = () => {
     }),
     ApiBody({ type: GoogleTokenDto }),
     ApiResponse({
-      status: 201,
+      status: 200,
       description: 'Đăng nhập thành công. Tokens lưu vào Cookie.',
       schema: {
         type: 'object',


### PR DESCRIPTION
Các framework như Express, Fastify, hoặc các công cụ bên hệ sinh thái khác (như Go Fiber, Gin, Flask của Python) không tự động định nghĩa sẵn mã 201 Created như NestJS.
Ngoài việc áp dụng mã 201 mặc định cho @Post(), NestJS còn sở hữu một số cơ chế xử lý ngầm (built-in behaviors) rất đặc trưng mà các framework tối giản như Express không tự động làm:

- Tự động map mã lỗi HTTP (HttpException Filter): Khi bạn throw một lỗi trong NestJS (ví dụ: throw new BadRequestException('...')), NestJS sẽ tự động bắt lấy lỗi này và chuyển đổi thành một cấu hình JSON chuẩn với mã trạng thái 400 tương ứng để trả về cho client. Ở Express, nếu bạn throw lỗi mà không viết middleware xử lý tập trung, server sẽ bị crash hoặc treo request.

- Mã mặc định cho các HTTP Method còn lại: Tất cả các decorator như @Get(), @Put(), @Delete(), @Patch() đều được NestJS cấu hình mặc định trả về mã 202 hoặc 200 OK. Đối với @Delete(), nếu bạn muốn trả về chuẩn 204 No Content (thành công nhưng không có dữ liệu trả về), bạn cũng phải dùng @HttpCode(204) giống như trường hợp xử lý API Login.

- Tự động gửi kèm Header Content-Type: application/json: Chỉ cần bạn trả về một Object hoặc một Array trong hàm xử lý của Controller, NestJS sẽ tự động hiểu, parse sang chuỗi JSON và gắn đúng header mà bạn không cần phải gọi hàm .json() thủ công.