### PR TITLE
Fix/trhgam/be/rate limiting 

### DIFF
--- a/backend/scripts/test-redis-rate-limit.ts
+++ b/backend/scripts/test-redis-rate-limit.ts
@@ -1,0 +1,80 @@
+import * as dotenv from 'dotenv';
+import Redis from 'ioredis';
+
+// Load environment variables from .env
+dotenv.config();
+
+const redisUrl = process.env.REDIS_URL;
+
+if (!redisUrl) {
+  console.error('REDIS_URL not found in env!');
+  process.exit(1);
+}
+
+console.log('Connecting to Redis...');
+
+const redis = new Redis(redisUrl);
+
+async function testRateLimit() {
+  const ip = '127.0.0.1';
+  const type = 'login';
+  const limit = 5;
+  const ttl = 60;
+  const blockDuration = 60; // 1 minute block
+
+  const blockKey = `rate_limit:block:${type}:${ip}`;
+  const failKey = `rate_limit:fail:${type}:${ip}`;
+
+  // 1. Clean up old keys first
+  await redis.del(blockKey);
+  await redis.del(failKey);
+  console.log('--- Resetted rate limit keys for test ---');
+
+  // 2. Simulate 5 login failures
+  for (let i = 1; i <= limit; i++) {
+    const isBlocked = await redis.get(blockKey);
+    if (isBlocked) {
+      const blockTtl = await redis.ttl(blockKey);
+      console.log(`Attempt ${i}: BLOCKED! TTL remaining: ${blockTtl} seconds.`);
+      break;
+    }
+
+    console.log(`Attempt ${i}: Simulating fail...`);
+    const currentFails = await redis.incr(failKey);
+    if (currentFails === 1) {
+      await redis.expire(failKey, ttl);
+    }
+
+    console.log(`  Fail count is now: ${currentFails}`);
+
+    if (currentFails >= limit) {
+      console.log(`  Threshold reached (${limit}). Setting block key for ${blockDuration} seconds.`);
+      await redis.set(blockKey, '1', 'EX', blockDuration);
+      await redis.del(failKey);
+    }
+  }
+
+  // 3. Verify that the next attempt is blocked and we can read the TTL
+  const isBlocked = await redis.get(blockKey);
+  if (isBlocked) {
+    const blockTtl = await redis.ttl(blockKey);
+    console.log(`Verification: Client is officially BLOCKED for ${blockTtl} more seconds.`);
+    if (blockTtl > 0 && blockTtl <= blockDuration) {
+      console.log('SUCCESS: The block duration of 60 seconds (1 minute) is working correctly!');
+    } else {
+      console.error('FAIL: Block TTL is invalid:', blockTtl);
+    }
+  } else {
+    console.error('FAIL: Client was not blocked!');
+  }
+
+  // Clean up
+  await redis.del(blockKey);
+  await redis.del(failKey);
+  redis.disconnect();
+}
+
+testRateLimit().catch((err) => {
+  console.error('Error during test:', err);
+  redis.disconnect();
+});

--- a/backend/src/common/decorators/rate-limit-fail.decorator.ts
+++ b/backend/src/common/decorators/rate-limit-fail.decorator.ts
@@ -1,0 +1,13 @@
+import { SetMetadata } from '@nestjs/common';
+
+export interface RateLimitFailOptions {
+  type: string;          // E.g., 'login' | 'register'
+  limit: number;         // Maximum allowed failures
+  ttl: number;           // Track duration in seconds (e.g., 60)
+  blockDuration: number; // Block duration in seconds (e.g., 60)
+}
+
+export const RATE_LIMIT_FAIL_KEY = 'rate_limit_fail';
+
+export const RateLimitFail = (options: RateLimitFailOptions) =>
+  SetMetadata(RATE_LIMIT_FAIL_KEY, options);

--- a/backend/src/common/interceptors/rate-limit-fail.interceptor.ts
+++ b/backend/src/common/interceptors/rate-limit-fail.interceptor.ts
@@ -1,0 +1,113 @@
+import {
+  CallHandler,
+  ExecutionContext,
+  Inject,
+  Injectable,
+  NestInterceptor,
+  HttpException,
+  HttpStatus,
+} from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import Redis from 'ioredis';
+import { REDIS_CLIENT } from 'src/modules/redis/redis.module';
+import {
+  RATE_LIMIT_FAIL_KEY,
+  RateLimitFailOptions,
+} from '../decorators/rate-limit-fail.decorator';
+import { Observable, from, throwError } from 'rxjs';
+import { catchError, mergeMap, tap } from 'rxjs/operators';
+
+@Injectable()
+export class RateLimitFailInterceptor implements NestInterceptor {
+  constructor(
+    private readonly reflector: Reflector,
+    @Inject(REDIS_CLIENT) private readonly redis: Redis,
+  ) {}
+
+  async intercept(
+    context: ExecutionContext,
+    next: CallHandler,
+  ): Promise<Observable<any>> {
+    const handler = context.getHandler();
+    const options = this.reflector.get<RateLimitFailOptions>(
+      RATE_LIMIT_FAIL_KEY,
+      handler,
+    );
+
+    if (!options) {
+      return next.handle();
+    }
+
+    const request = context.switchToHttp().getRequest();
+    const ip = this.getClientIp(request);
+
+    const blockKey = `rate_limit:block:${options.type}:${ip}`;
+    const failKey = `rate_limit:fail:${options.type}:${ip}`;
+
+    // Pre-handler: Check if the IP is blocked
+    const isBlocked = await this.redis.get(blockKey);
+    if (isBlocked) {
+      const ttl = await this.redis.ttl(blockKey);
+      const waitTime = ttl > 0 ? ttl : options.blockDuration;
+      throw new HttpException(
+        `Bạn đã thử thất bại quá nhiều lần. Vui lòng thử lại sau ${waitTime} giây.`,
+        HttpStatus.TOO_MANY_REQUESTS,
+      );
+    }
+
+    return next.handle().pipe(
+      // On success: Clear failure count
+      tap(() => {
+        this.redis.del(failKey).catch((err) => {
+          console.error(
+            `[RateLimitFailInterceptor] Error deleting fail key:`,
+            err,
+          );
+        });
+      }),
+      // On failure: Handle counting and blocking
+      catchError((error) => {
+        // If already a 429 error, just propagate it
+        if (
+          error instanceof HttpException &&
+          error.getStatus() === HttpStatus.TOO_MANY_REQUESTS
+        ) {
+          return throwError(() => error);
+        }
+
+        const handleFailurePromise = (async () => {
+          try {
+            const currentFails = await this.redis.incr(failKey);
+            if (currentFails === 1) {
+              await this.redis.expire(failKey, options.ttl);
+            }
+
+            if (currentFails >= options.limit) {
+              await this.redis.set(blockKey, '1', 'EX', options.blockDuration);
+              await this.redis.del(failKey);
+            }
+          } catch (redisError) {
+            console.error(
+              `[RateLimitFailInterceptor] Redis tracking error:`,
+              redisError,
+            );
+          }
+        })();
+
+        // Resolve the async operation, then propagate the original error
+        return from(handleFailurePromise).pipe(
+          mergeMap(() => throwError(() => error)),
+        );
+      }),
+    );
+  }
+
+  private getClientIp(request: any): string {
+    return (
+      request.headers['x-forwarded-for']?.split(',')[0]?.trim() ||
+      request.ip ||
+      request.connection?.remoteAddress ||
+      '127.0.0.1'
+    );
+  }
+}

--- a/backend/src/modules/auth/auth.controller.ts
+++ b/backend/src/modules/auth/auth.controller.ts
@@ -18,6 +18,8 @@ import { AuthService } from './services/auth.service';
 import { LoginDto, GoogleTokenDto, RegisterDto } from './dtos/auth.dto';
 import { GoogleAuthGuard } from './guards/google-auth.guard';
 import { AUTH_MESSAGES } from 'src/common/constants/message.constant';
+import { RateLimitFail } from 'src/common/decorators/rate-limit-fail.decorator';
+import { RateLimitFailInterceptor } from 'src/common/interceptors/rate-limit-fail.interceptor';
 import { ApiTags } from '@nestjs/swagger';
 import {
   ApiRegisterDoc,
@@ -37,6 +39,8 @@ export class AuthController {
 
   @Public()
   @Post('register')
+  @UseInterceptors(RateLimitFailInterceptor)
+  @RateLimitFail({ type: 'register', limit: 3, ttl: 60, blockDuration: 60 })
   @ApiRegisterDoc()
   @ApiRegisterDoc()
   async register(
@@ -54,6 +58,8 @@ export class AuthController {
   @Public()
   @Post('login')
   @HttpCode(HttpStatus.OK)
+  @UseInterceptors(RateLimitFailInterceptor)
+  @RateLimitFail({ type: 'login', limit: 5, ttl: 60, blockDuration: 60 })
   @ApiLoginDoc()
   async login(
     @Body() loginDto: LoginDto,


### PR DESCRIPTION
# Báo Cáo Thay Đổi Hệ Thống: Cấu Hình Rate Limit Khi Thực Hiện Thất Bại

---

## 1. Decorator `@RateLimitFail`
* **File:** `rate-limit-fail.decorator.ts`
* **Mục đích:** Cấu hình các thông số rate limit riêng biệt cho từng API (như số lần tối đa, thời gian theo dõi, thời gian block).

---

## 2. Interceptor `RateLimitFailInterceptor`
* **File:** `rate-limit-fail.interceptor.ts`
* **Mục đích:** Tận dụng cơ chế Interceptor để xử lý logic qua hai pha:
  * **Pre-handler (Trước khi chạy API):** Đọc IP của client và kiểm tra trong Redis xem IP này đang bị block hay không. Nếu có, tính toán thời gian khóa còn lại (TTL) và trả về lỗi `429 Too Many Requests` kèm câu báo lỗi chi tiết.
  * **Post-handler (Sau khi chạy API):**
    * *Nếu thành công:* Xóa dữ liệu fail của IP này trong Redis (reset về 0).
    * *Nếu thất bại:* Tăng số lần fail của IP này trong Redis. Khi đạt ngưỡng giới hạn, ghi nhận block IP này trong vòng 60 giây và xóa bộ đếm cũ.

---

## 3. Áp dụng lên Controller
* **File:** `auth.controller.ts`
* **Mục đích:** Đăng ký interceptor và cấu hình cụ thể cho từng API:
  * **API Register:** Chặn 1 phút sau khi đăng ký thất bại 3 lần liên tiếp.
  * **API Login:** Chặn 1 phút sau khi đăng nhập thất bại 5 lần liên tiếp.

> **Xác minh về yêu cầu của BA (Google OAuth Cancel):**
> Vì API Google Login (`/auths/google/callback`) hoàn toàn độc lập và không khai báo decorator `@RateLimitFail`, mọi lỗi hủy bỏ hay xác thực từ phía Google đều không bị tính là thất bại và không bị block IP, đáp ứng hoàn hảo yêu cầu của BA.