### PR TITLE
feat: add extra connection pool

### DIFF
--- a/backend/src/infrastructure/database/database.module.ts
+++ b/backend/src/infrastructure/database/database.module.ts
@@ -23,6 +23,11 @@ import { ConfigService } from '@nestjs/config';
         synchronize: configService.get<boolean>('database.synchronize'), // Đọc từ biến môi trường
         logging: configService.get<string>('logLevel') === 'debug', // Chỉ in câu lệnh SQL khi LOG_LEVEL=debug
         ssl: false, // Nếu DB server yêu cầu SSL thì mới để true
+        extra: {
+          max: 20, // Số lượng connection tối đa trong pool (mặc định là 10)
+          idleTimeoutMillis: 30000, // Thời gian (ms) đóng connection rảnh rỗi (mặc định 30s)
+          connectionTimeoutMillis: 2000, // Thời gian chờ (ms) tối đa để lấy connection từ pool (mặc định 0 - chờ vô hạn)
+        },
       }),
     }),
   ],


### PR DESCRIPTION
### 📝 Description
Bổ sung cấu hình tường minh cho **Database Connection Pool** (PostgreSQL) thông qua cấu hình `extra` của TypeORM trong `DatabaseModule`. 

###  Thay đổi chi tiết
- **File chỉnh sửa:** `src/infrastructure/database/database.module.ts`
- **Cấu hình bổ sung:**
  - `max: 20`: Tăng giới hạn số lượng kết nối đồng thời từ 10 (mặc định) lên 20 nhằm đáp ứng tải tốt hơn khi hệ thống có nhiều truy vấn song song.
  - `idleTimeoutMillis: 30000`: Tự động ngắt và giải phóng kết nối rảnh rỗi sau 30 giây để tiết kiệm tài nguyên cho Database.
  - `connectionTimeoutMillis: 2000`: Giới hạn thời gian chờ lấy kết nối từ pool tối đa là 2 giây. Nếu quá hạn sẽ trả về lỗi (fail-fast) thay vì treo request vô hạn, giúp ngăn chặn tràn bộ nhớ (out of memory) trên Backend.

###  Lợi ích mang lại
1. **Tối ưu hiệu năng:** Tránh việc tạo/đóng kết nối vật lý liên tục cho từng API request, tăng tốc độ phản hồi.
2. **Hệ thống bền bỉ hơn (Resilience):** Cơ chế timeout (2s) giúp bảo vệ Backend không bị treo hoặc cạn kiệt tài nguyên khi Database gặp sự cố hoặc bị quá tải kết nối.
3. **Tường minh code:** Cấu hình rõ ràng giúp các thành viên khác trong dự án dễ dàng kiểm soát và tối ưu các chỉ số kết nối sau này.

